### PR TITLE
Fix programming typo and update PiL links on members page to resolve 404s

### DIFF
--- a/_researchareas/pil-research.md
+++ b/_researchareas/pil-research.md
@@ -19,7 +19,7 @@ verification and validation of software sytems at the programming language level
 
 ### Smart Environments
 
-Our main application domain is on smart adaptive systems, which include smart cities, smart transport, IoT and cyberphysical environments. In this domain area we work on Context-oriented Porgramming (COP) languages as a driver to foster smarter systems that can react to the conditions of their surrounding environment and offer the most appropriate behavior to users.
+Our main application domain is on smart adaptive systems, which include smart cities, smart transport, IoT and cyberphysical environments. In this domain area we work on Context-oriented Programming (COP) languages as a driver to foster smarter systems that can react to the conditions of their surrounding environment and offer the most appropriate behavior to users.
 
 ### Interconnected Environments
 

--- a/members.html
+++ b/members.html
@@ -38,7 +38,7 @@ role-tables:
                 <div class="card-img-overlay d-flex flex-column justify-content-end" style="padding: 0px">
                     <div style="background-color: #363636aa; color: white; padding-left: 5px">
                         <h4 class="card-title" style="margin-bottom: 0px">
-                            <a href="{{site.base}}/researchareas/{{person.main-subgroup}}-research.html">
+                            <a href="{{site.base}}/researchareas/{{person.main-subgroup | downcase}}-research.html">
                                 <img style="aspect-ratio: 1/1; width: 25px;" src = "{{ site.base }}/img/{{person.main-subgroup}}.png">
                             </a>
                              {{person.display_name}}
@@ -56,7 +56,7 @@ role-tables:
             <div class="card-img-overlay d-flex flex-column justify-content-end" style="padding: 0px">
                 <div style="background-color: #363636aa; color: white; padding-left: 5px">
                     <h4 class="card-title" style="margin-bottom: 0px">
-                        <a href="{{site.base}}/researchareas/{{person.main-subgroup}}-research.html">
+                        <a href="{{site.base}}/researchareas/{{person.main-subgroup | downcase}}-research.html">
                             <img style="aspect-ratio: 1/1; width: 25px;" src = "{{ site.base }}/img/{{person.main-subgroup}}.png">
                         </a>
                          {{person.display_name}}

--- a/past-members.html
+++ b/past-members.html
@@ -33,7 +33,7 @@ role-tables:
         <div class="card bg-inverse p-2">
             <a href="{{person.webpage}}" target="_blank">
                 <div class="card-img-overlay d-flex flex-column justify-content-end" style="padding: 0px">
-                            <a href="{{site.base}}/researchareas/{{person.main-subgroup}}-research.html">
+                            <a href="{{site.base}}/researchareas/{{person.main-subgroup | downcase}}-research.html">
                                 <img style="aspect-ratio: 1/1; width: 25px;" src = "{{ site.base }}/img/{{person.main-subgroup}}.png">
                             </a>
                              {{person.display_name}} - {{person.bio}}


### PR DESCRIPTION
Fix typo ("porgramming" → "programming") and correct PiL links in members page to resolve 404 errors
---
# typo 
<img width="1319" height="798" alt="image" src="https://github.com/user-attachments/assets/06a5d3fd-0551-40fe-863b-e133022abbca" />

---
# 404
<img width="1152" height="790" alt="Sin título" src="https://github.com/user-attachments/assets/ae4f81fc-627b-43b1-a838-a50154a9c9ab" />
<img width="600" height="305" alt="image" src="https://github.com/user-attachments/assets/3cbcd39a-d98a-4955-934c-b06baac1d963" />

